### PR TITLE
Sort interpreter list correctly

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -379,10 +379,10 @@ public class InterpreterFactory {
       List<InterpreterSetting.InterpreterInfo> interpreterInfos =
           new LinkedList<InterpreterSetting.InterpreterInfo>();
 
-      for (RegisteredInterpreter registeredInterpreter :
-          Interpreter.registeredInterpreters.values()) {
-        if (registeredInterpreter.getGroup().equals(groupName)) {
-          for (String className : interpreterClassList) {
+      for (String className : interpreterClassList) {
+        for (RegisteredInterpreter registeredInterpreter :
+            Interpreter.registeredInterpreters.values()) {
+          if (registeredInterpreter.getGroup().equals(groupName)) {
             if (registeredInterpreter.getClassName().equals(className)) {
               interpreterInfos.add(
                   new InterpreterSetting.InterpreterInfo(


### PR DESCRIPTION
This patch make  '%r' displayed in interpreter list.

![image](https://cloud.githubusercontent.com/assets/1540981/14124743/13a33b2e-f5bc-11e5-87cd-f804220cd8f9.png)
